### PR TITLE
refactor: native select dropdown

### DIFF
--- a/filters/components/Zero_Filters__SortBySelector.vue
+++ b/filters/components/Zero_Filters__SortBySelector.vue
@@ -5,7 +5,7 @@
     v-click-outside="closeAllSelect"
     :class="['dropdown-wrapper', 'focus-visible', { closed }]"
     :style="{ minWidth: `${maxLength * 10}px` }"
-    @keyup="(e) => handleKeyboardInteraction(e)">
+    @keyup="handleKeyboardInteraction($event)">
 
     <div
       ref="dropdownButton"

--- a/filters/components/Zero_Filters__SortBySelector.vue
+++ b/filters/components/Zero_Filters__SortBySelector.vue
@@ -12,7 +12,7 @@
       class="dropdown-button"
       @click.stop="toggleDropDown()">
 
-      <label for="dropdown-native-select">
+      <label for="sortby-native-select">
         {{ label }}
       </label>
 
@@ -28,7 +28,7 @@
 
     <select
       ref="nativeSelect"
-      id="dropdown-native-select"
+      id="sortby-native-select"
       v-model="selected"
       class="select-native">
       <template v-for="option in options">
@@ -128,7 +128,6 @@ export default {
       }
     },
     selected (val) {
-      console.log(val)
       const obj = this.options.find(item => item.label === val)
       if (obj.type === 'alphabetical') {
         this.sortAlphabetically(obj.key, obj.direction)
@@ -208,22 +207,6 @@ export default {
     optionSelected (obj) {
       this.selected = obj.label
       this.closeAllSelect()
-      // if (obj.type === 'alphabetical') {
-      //   this.sortAlphabetically(obj.key, obj.direction)
-      // } else if (obj.type === 'number') {
-      //   this.sortNumerically(obj.sortNumber, obj.direction)
-      // }
-      // this.setRouteQuery({
-      //   key: 'sort-by',
-      //   data: obj.slug
-      // })
-      // this.$emit('changed', {
-      //   event: 'optionSelected',
-      //   data: {
-      //     label: obj.label,
-      //     slug: obj.slug
-      //   }
-      // })
     },
     sortAlphabetically (key, mode) {
       if (this.collection.array) {
@@ -262,9 +245,9 @@ export default {
 
 .select-native {
   position: absolute;
-  right: 20rem;
+  right: 0rem;
   top: 0;
-  opacity: 0.5;
+  opacity: 0;
   z-index: -10;
   &:focus {
     top: 100%;

--- a/filters/components/Zero_Filters__SortBySelector.vue
+++ b/filters/components/Zero_Filters__SortBySelector.vue
@@ -5,14 +5,14 @@
     v-click-outside="closeAllSelect"
     :class="['dropdown-wrapper', 'focus-visible', { closed }]"
     :style="{ minWidth: `${maxLength * 10}px` }"
-    @keyup.enter="toggleDropDown()">
+    @keyup="(e) => handleKeyboardInteraction(e)">
 
     <div
       ref="dropdownButton"
       class="dropdown-button"
-      @click="toggleDropDown()">
+      @click.stop="toggleDropDown()">
 
-      <label>
+      <label for="dropdown-native-select">
         {{ label }}
       </label>
 
@@ -26,15 +26,28 @@
 
     </div>
 
+    <select
+      ref="nativeSelect"
+      id="dropdown-native-select"
+      v-model="selected"
+      class="select-native">
+      <template v-for="option in options">
+        <option
+          :key="`select-option-${option.label}`"
+          :value="option.label">
+          {{ option.label }}
+        </option>
+      </template>
+    </select>
+
     <div class="dropdown-root" :style="{ paddingTop: `${dropdownButtonHeight}px`, height: `${height}px` }">
 
-      <div ref="dropdownList" class="dropdown-list">
+      <div ref="dropdownList" class="dropdown-list" aria-hidden="true">
         <template v-for="option in options">
           <div
             :key="`div-option-${option.label}`"
             :value="option.label"
             :class="['dropdown-item', 'focus-visible', { highlighted: (selected === option.label) }]"
-            :tabindex="closed ? -1 : 0"
             @click="optionSelected(option)"
             @keyup.enter.self="optionSelected(option)">
             {{ option.label }}
@@ -113,6 +126,26 @@ export default {
           })
         }
       }
+    },
+    selected (val) {
+      console.log(val)
+      const obj = this.options.find(item => item.label === val)
+      if (obj.type === 'alphabetical') {
+        this.sortAlphabetically(obj.key, obj.direction)
+      } else if (obj.type === 'number') {
+        this.sortNumerically(obj.sortNumber, obj.direction)
+      }
+      this.setRouteQuery({
+        key: 'sort-by',
+        data: obj.slug
+      })
+      this.$emit('changed', {
+        event: 'optionSelected',
+        data: {
+          label: obj.label,
+          slug: obj.slug
+        }
+      })
     }
   },
 
@@ -175,22 +208,22 @@ export default {
     optionSelected (obj) {
       this.selected = obj.label
       this.closeAllSelect()
-      if (obj.type === 'alphabetical') {
-        this.sortAlphabetically(obj.key, obj.direction)
-      } else if (obj.type === 'number') {
-        this.sortNumerically(obj.sortNumber, obj.direction)
-      }
-      this.setRouteQuery({
-        key: 'sort-by',
-        data: obj.slug
-      })
-      this.$emit('changed', {
-        event: 'optionSelected',
-        data: {
-          label: obj.label,
-          slug: obj.slug
-        }
-      })
+      // if (obj.type === 'alphabetical') {
+      //   this.sortAlphabetically(obj.key, obj.direction)
+      // } else if (obj.type === 'number') {
+      //   this.sortNumerically(obj.sortNumber, obj.direction)
+      // }
+      // this.setRouteQuery({
+      //   key: 'sort-by',
+      //   data: obj.slug
+      // })
+      // this.$emit('changed', {
+      //   event: 'optionSelected',
+      //   data: {
+      //     label: obj.label,
+      //     slug: obj.slug
+      //   }
+      // })
     },
     sortAlphabetically (key, mode) {
       if (this.collection.array) {
@@ -215,12 +248,29 @@ export default {
         const payload = { type: 'sorted', collection: cloned }
         this.setCollection(payload)
       }
+    },
+    handleKeyboardInteraction (e) {
+      if (e.key === 'Enter' || e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+        this.$refs.nativeSelect.focus()
+      }
     }
   }
 }
 </script>
 
 <style lang="scss" scoped>
+
+.select-native {
+  position: absolute;
+  right: 20rem;
+  top: 0;
+  opacity: 0.5;
+  z-index: -10;
+  &:focus {
+    top: 100%;
+  }
+}
+
 ::selection {
   color: none;
   background: none;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@agency-undone/au-nuxt-module-zero",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agency-undone/au-nuxt-module-zero",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Nuxt module that contains a variety of boilerplate components and functions",
   "homepage": "https://github.com/agency-undone/au-nuxt-module-zero/#readme",
   "bugs": "https://github.com/agency-undone/au-nuxt-module-zero/issues",

--- a/pagination/components/Zero_Pagination__ResultsPerPageSelector.vue
+++ b/pagination/components/Zero_Pagination__ResultsPerPageSelector.vue
@@ -8,9 +8,9 @@
 
     <div class="dropdown dropdown-button" @click.stop="toggleDropdown()">
 
-      <span id="rpp-selector-label">
+      <label for="dropdown-native-select">
         {{ label + (display === totalItems ? 'All' : display) }}
-      </span>
+      </label>
 
       <div class="dropdown dropdown-slot">
         <slot name="dropdown-icon"></slot>
@@ -20,6 +20,7 @@
 
     <select
       ref="nativeSelect"
+      id="dropdown-native-select"
       v-model="selection"
       class="select-native">
       <template v-for="option in options">

--- a/pagination/components/Zero_Pagination__ResultsPerPageSelector.vue
+++ b/pagination/components/Zero_Pagination__ResultsPerPageSelector.vue
@@ -4,7 +4,7 @@
     id="results-per-page-selector"
     v-click-outside="closeAllSelect"
     :class="['dropdown-root', 'focus-visible', { closed }]"
-    @keyup="(e) => handleKeyboardInteraction(e)">
+    @keyup="handleKeyboardInteraction($event)">
 
     <div class="dropdown dropdown-button" @click.stop="toggleDropdown()">
 

--- a/pagination/components/Zero_Pagination__ResultsPerPageSelector.vue
+++ b/pagination/components/Zero_Pagination__ResultsPerPageSelector.vue
@@ -8,19 +8,28 @@
 
     <div class="dropdown dropdown-button" @click.stop="toggleDropdown()">
 
-      <label>
+      <span id="rpp-selector-label">
         {{ label + (display === totalItems ? 'All' : display) }}
-      </label>
+      </span>
 
       <div class="dropdown dropdown-slot">
-
         <slot name="dropdown-icon"></slot>
-
       </div>
 
     </div>
 
-    <div class="dropdown dropdown-list">
+    <select class="select-native" aria-labelledby="rpp-selector-label">
+      <template v-for="option in options">
+        <option
+          v-if="!isNaN(option)"
+          :key="`select-option-${option}`"
+          :value="option">
+          {{ option === totalItems ? 'All' : option }}
+        </option>
+      </template>
+    </select>
+
+    <div class="dropdown dropdown-list" aria-hidden="true">
       <template v-for="option in options">
         <div
           v-if="!isNaN(option)"
@@ -173,6 +182,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+
 ::selection {
   color: none;
   background: none;

--- a/pagination/components/Zero_Pagination__ResultsPerPageSelector.vue
+++ b/pagination/components/Zero_Pagination__ResultsPerPageSelector.vue
@@ -4,7 +4,7 @@
     id="results-per-page-selector"
     v-click-outside="closeAllSelect"
     :class="['dropdown-root', 'focus-visible', { closed }]"
-    @keyup.enter="handleKeyboardInteraction()">
+    @keyup="(e) => handleKeyboardInteraction(e)">
 
     <div class="dropdown dropdown-button" @click.stop="toggleDropdown()">
 
@@ -38,7 +38,6 @@
           v-if="!isNaN(option)"
           :key="`div-option-${option}`"
           :value="option"
-          :tabindex="closed ? -1 : 0"
           class="dropdown dropdown-item focus-visible"
           :class="{ highlighted: (display === option) }"
           @click="optionSelected(option)"
@@ -146,6 +145,7 @@ export default {
   },
 
   mounted () {
+    this.selection = this.display
     if (this.addParamOnLoad && this.display) {
       this.optionSelected(this.display)
     }
@@ -187,8 +187,10 @@ export default {
       }
       this.toggleDropdown()
     },
-    handleKeyboardInteraction () {
-      this.$refs.nativeSelect.focus()
+    handleKeyboardInteraction (e) {
+      if (e.key === 'Enter' || e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+        this.$refs.nativeSelect.focus()
+      }
     }
   }
 }
@@ -198,7 +200,13 @@ export default {
 
 .select-native {
   position: absolute;
-  left: 20rem;
+  right: 0;
+  top: 0;
+  opacity: 0;
+  z-index: -10;
+  &:focus {
+    top: 100%;
+  }
 }
 
 ::selection {

--- a/pagination/components/Zero_Pagination__ResultsPerPageSelector.vue
+++ b/pagination/components/Zero_Pagination__ResultsPerPageSelector.vue
@@ -4,7 +4,7 @@
     id="results-per-page-selector"
     v-click-outside="closeAllSelect"
     :class="['dropdown-root', 'focus-visible', { closed }]"
-    @keyup.enter="toggleDropdown()">
+    @keyup.enter="handleKeyboardInteraction()">
 
     <div class="dropdown dropdown-button" @click.stop="toggleDropdown()">
 
@@ -18,7 +18,10 @@
 
     </div>
 
-    <select class="select-native" aria-labelledby="rpp-selector-label">
+    <select
+      ref="nativeSelect"
+      v-model="selection"
+      class="select-native">
       <template v-for="option in options">
         <option
           v-if="!isNaN(option)"
@@ -87,7 +90,8 @@ export default {
 
   data () {
     return {
-      closed: true
+      closed: true,
+      selection: 10
     }
   },
 
@@ -115,6 +119,29 @@ export default {
         displayOptions.push(total)
       }
       return displayOptions
+    }
+  },
+
+  watch: {
+    selection (val) {
+      this.setRouteQuery({
+        key: 'results',
+        data: val
+      })
+      this.calculateTotalPages()
+      const total = this.totalPages
+      if (this.page > total) {
+        this.setRouteQuery({
+          key: 'page',
+          data: total
+        })
+      }
+      this.$emit('changed', {
+        event: 'optionSelected',
+        data: {
+          option: val
+        }
+      })
     }
   },
 
@@ -156,32 +183,23 @@ export default {
     optionSelected (val) {
       const selection = parseInt(val)
       if (!isNaN(selection)) {
-        this.setRouteQuery({
-          key: 'results',
-          data: selection
-        })
-        this.calculateTotalPages()
-        const total = this.totalPages
-        if (this.page > total) {
-          this.setRouteQuery({
-            key: 'page',
-            data: total
-          })
-        }
-        this.$emit('changed', {
-          event: 'optionSelected',
-          data: {
-            option: selection
-          }
-        })
-        this.toggleDropdown()
+        this.selection = selection
       }
+      this.toggleDropdown()
+    },
+    handleKeyboardInteraction () {
+      this.$refs.nativeSelect.focus()
     }
   }
 }
 </script>
 
 <style lang="scss" scoped>
+
+.select-native {
+  position: absolute;
+  left: 20rem;
+}
 
 ::selection {
   color: none;


### PR DESCRIPTION
This PR refactors the two dropdown components; SortBySelector in `/filters/components` and ResultsPerPageSelector in `/pagination/components`. Native select elements have been added to both components which are hidden behind the existing dropdown menus and only appear when a keyboard interacts with the dropdown. Choosing an option on either the native select or dropdown synchronizes selected values across all elements using v-model.