### PR TITLE
feat: exit server if https keys missing in dev environment

### DIFF
--- a/core/index.js
+++ b/core/index.js
@@ -191,9 +191,14 @@ const registerPlugins = (instance, next) => {
 const runHttps = (instance, next) => {
   if (process.env.NODE_ENV === 'development' && typeof instance.options.server === 'object') {
     const rootPath = instance.options.alias['@']
-    instance.options.server.https = {
-      key: Fs.readFileSync(Path.resolve(instance.options.rootDir, 'localhost_key.pem')),
-      cert: Fs.readFileSync(Path.resolve(instance.options.rootDir, 'localhost_cert.pem'))
+    try {
+      instance.options.server.https = {
+        key: Fs.readFileSync(Path.resolve(instance.options.rootDir, 'localhost_key.pem')),
+        cert: Fs.readFileSync(Path.resolve(instance.options.rootDir, 'localhost_cert.pem'))
+      }
+    } catch (e) {
+      console.log(e)
+      process.exit(0)
     }
   }
   if (next) { return next() }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@agency-undone/au-nuxt-module-zero",
-  "version": "1.0.18",
+  "version": "1.0.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agency-undone/au-nuxt-module-zero",
-  "version": "1.0.18",
+  "version": "1.0.20",
   "description": "Nuxt module that contains a variety of boilerplate components and functions",
   "homepage": "https://github.com/agency-undone/au-nuxt-module-zero/#readme",
   "bugs": "https://github.com/agency-undone/au-nuxt-module-zero/issues",


### PR DESCRIPTION
If `localhost_cert.pem` or `localhost_key.pem` are missing when `NODE_ENV=development`, then running `npm run dev` or any other script will exit the process (re: the server won't start).